### PR TITLE
fix: 防止名字包含恶意空白

### DIFF
--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/service/adapter/UserAdapter.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/service/adapter/UserAdapter.java
@@ -38,10 +38,11 @@ public class UserAdapter {
         user.setAvatar(userInfo.getHeadImgUrl());
         user.setName(userInfo.getNickname());
         user.setSex(userInfo.getSex());
-        if (userInfo.getNickname().length() > 6) {
+        String nickname = userInfo.getNickname().replaceAll("\\s+|\\p{C}", "");
+        if (nickname.length() > 6) {
             user.setName("名字过长" + RandomUtil.randomInt(100000));
         } else {
-            user.setName(userInfo.getNickname());
+            user.setName(nickname);
         }
         return user;
     }


### PR DESCRIPTION
## 问题描述
未过滤掉特殊空白文本
<img width="458" alt="image" src="https://github.com/zongzibinbin/MallChat/assets/48879481/0fa41d7f-59c7-4a45-9b80-908e1c65ce97">
