### PR TITLE
style:代码风格规范

### DIFF
--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/utils/RedisUtils.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/utils/RedisUtils.java
@@ -25,7 +25,7 @@ public class RedisUtils {
 
     @PostConstruct
     public void init() {
-        this.stringRedisTemplate = SpringUtil.getBean(StringRedisTemplate.class);
+        RedisUtils.stringRedisTemplate = SpringUtil.getBean(StringRedisTemplate.class);
     }
 
     private static final String LUA_INCR_EXPIRE =

--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/chat/service/strategy/msg/TextMsgHandler.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/chat/service/strategy/msg/TextMsgHandler.java
@@ -46,7 +46,7 @@ public class TextMsgHandler extends AbstractMsgHandler {
     private UserInfoCache userInfoCache;
     @Autowired
     private IRoleService iRoleService;
-    @Autowired
+    
     private static final PrioritizedUrlTitleDiscover URL_TITLE_DISCOVER = new PrioritizedUrlTitleDiscover();
 
     @Override


### PR DESCRIPTION
TextMsgHandler中自动装配规范问题修改。static 成员不应该使用Autowired注解装配；且会找不到PrioritizedUrlTitleDiscover类型的bean对象。修复方式为：去除@Autowired注解，使用new方式创建对象