### PR TITLE
update: add UUID generator

### DIFF
--- a/mallchat-common/pom.xml
+++ b/mallchat-common/pom.xml
@@ -112,6 +112,11 @@
             <groupId>io.minio</groupId>
             <artifactId>minio</artifactId>
         </dependency>
+        <!--UUID生成器-->
+        <dependency>
+            <groupId>com.github.yitter</groupId>
+            <artifactId>yitter-idgenerator</artifactId>
+        </dependency>
         <!-- Used for unit testing -->
         <dependency>
             <groupId>junit</groupId>

--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/config/UUIDConfig.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/config/UUIDConfig.java
@@ -1,0 +1,55 @@
+package com.abin.mallchat.common.common.config;
+
+import com.github.yitter.contract.IdGeneratorOptions;
+import com.github.yitter.idgen.YitIdHelper;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Description: UUID生成器的配置类
+ * Author: <a href="https://www.ahao.homes">ahao: https://github.com/HowlsLee</a>
+ * <p>
+ * <p>
+ * <p>
+ * 采用开源的yitter-idgenerator生成唯一Id
+ * <p>
+ * 1. 可以代替自带的UUID: UUID.randomUUID()
+ * 2. 优化了传统的雪花算法：
+ * 整形数字，随时间单调递增（不一定连续），长度更短，用50年都不会超过 js Number类型最大值。（默认配置）
+ * 速度更快，是传统雪花算法的2-5倍，0.1秒可生成50万个（基于8代低压i7）。
+ * ...
+ * 参考：https://github.com/yitter/IdGenerator
+ */
+@Configuration
+public class UUIDConfig {
+
+    /**
+     * workerId表示该服务实例的唯一标识(可以为0, 1, 2, 3 , ..., n),
+     * 关联配置项中的"WorkerIdBitLength"字段
+     * <p>
+     * 单机部署下workerId可以不设置或者设置成全局唯一的值即可(目前为0)
+     * 多节点部署下，workerId可以从分布式中心比如Redis分配得到：
+     * 内部维护2个key:
+     * 1. 已注册的实例集合
+     * 2. 当前已分配的workerId的最大值(初始值可以为0)
+     * 获取workerId步骤：
+     * 1. 采用(Mac地址 + 进程号)作为key到Redis中查询该实例是否注册
+     * 如果没注册则将当前最大workerId分配，并且Redis中最大workerId + 1
+     * 否则获取之前分配的workerId
+     **/
+    private static final short workerId = (short) (0);
+
+    @PostConstruct
+    public void init() {
+        // 创建 IdGeneratorOptions 对象，可在构造函数中输入 WorkerId：
+        IdGeneratorOptions options = new IdGeneratorOptions(workerId);
+        // options.WorkerIdBitLength = 10; // 默认值6，限定 WorkerId 最大值为2^6-1，即默认最多支持64个节点。
+        // options.SeqBitLength = 6; // 默认值6，限制每毫秒生成的ID个数。若生成速度超过5万个/秒，建议加大 SeqBitLength 到 10。
+        // options.BaseTime = Your_Base_Time; // 如果要兼容老系统的雪花算法，此处应设置为老系统的BaseTime。
+        // ...... 其它参数参考 IdGeneratorOptions 定义。
+        // 保存参数（务必调用，否则参数设置不生效）：
+        YitIdHelper.setIdGenerator(options);
+        // 以上过程只需全局一次，且应在生成ID之前完成。
+    }
+}

--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/utils/UUIDUtil.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/utils/UUIDUtil.java
@@ -1,0 +1,14 @@
+package com.abin.mallchat.common.common.utils;
+
+import com.github.yitter.idgen.YitIdHelper;
+
+/**
+ * Description: UUID生成器工具类
+ * Author: <a href="https://www.ahao.homes">ahao: https://github.com/HowlsLee</a>
+ */
+public class UUIDUtil {
+
+    public static String getId() {
+        return String.valueOf(YitIdHelper.nextId());
+    }
+}

--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/common/intecepter/HttpTraceIdFilter.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/common/intecepter/HttpTraceIdFilter.java
@@ -1,6 +1,7 @@
 package com.abin.mallchat.custom.common.intecepter;
 
 import com.abin.mallchat.common.common.constant.MDCKey;
+import com.abin.mallchat.common.common.utils.UUIDUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 
@@ -20,7 +21,7 @@ public class HttpTraceIdFilter implements Filter {
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        String tid = UUID.randomUUID().toString();
+        String tid = UUIDUtil.getId();
         MDC.put(MDCKey.TID, tid);
         chain.doFilter(request, response);
     }

--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/websocket/NettyCollectorHandler.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/websocket/NettyCollectorHandler.java
@@ -3,6 +3,7 @@ package com.abin.mallchat.custom.user.websocket;
 import com.abin.mallchat.common.common.constant.MDCKey;
 import com.abin.mallchat.common.common.domain.dto.RequestInfo;
 import com.abin.mallchat.common.common.utils.RequestHolder;
+import com.abin.mallchat.common.common.utils.UUIDUtil;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import lombok.extern.slf4j.Slf4j;
@@ -15,7 +16,7 @@ import java.util.UUID;
 public class NettyCollectorHandler extends ChannelInboundHandlerAdapter {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
-        String tid = UUID.randomUUID().toString();
+        String tid = UUIDUtil.getId();
         MDC.put(MDCKey.TID, tid);
         RequestInfo info = new RequestInfo();
         info.setUid(NettyUtil.getAttr(ctx.channel(), NettyUtil.UID));

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
         <jsoup.version>1.15.3</jsoup.version>
         <okhttp.version>4.8.1</okhttp.version>
         <redisson-spring-boot-starter.version>3.17.1</redisson-spring-boot-starter.version>
+        <yitter-idgenerator.version>1.0.6</yitter-idgenerator.version>
     </properties>
 
     <dependencyManagement>
@@ -129,6 +130,12 @@
                 <groupId>org.redisson</groupId>
                 <artifactId>redisson-spring-boot-starter</artifactId>
                 <version>${redisson-spring-boot-starter.version}</version>
+            </dependency>
+            <!--UUID生成器-->
+            <dependency>
+                <groupId>com.github.yitter</groupId>
+                <artifactId>yitter-idgenerator</artifactId>
+                <version>${yitter-idgenerator.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
采用开源的yitter-idgenerator生成分布式唯一Id
 * 可以代替自带的UUID: UUID.randomUUID()
 * 优化了传统的雪花算法：
 * 整形数字，随时间单调递增（不一定连续），长度更短，用50年都不会超过 js Number类型最大值。（默认配置）
 * 速度更快，是传统雪花算法的2-5倍，0.1秒可生成50万个（基于8代低压i7）。
 * ...
 * 参考：https://github.com/yitter/IdGenerator