### PR TITLE
fix: 修复解析url标题前端无法正确跳转

### DIFF
--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/utils/discover/AbstractUrlTitleDiscover.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/utils/discover/AbstractUrlTitleDiscover.java
@@ -35,7 +35,8 @@ public abstract class AbstractUrlTitleDiscover implements UrlTitleDiscover {
         if (StrUtil.isBlank(content)) {
             return new HashMap<>();
         }
-        List<String> matchList = ReUtil.findAll(PATTERN, content, 0);
+        List<String> matchList = ReUtil.findAll(PATTERN, content, 0)
+                .stream().filter(url -> url.startsWith("http://") || url.startsWith("https://")).collect(Collectors.toList());
         //并行请求
         List<CompletableFuture<Pair<String, String>>> futures = matchList.stream().map(match -> CompletableFuture.supplyAsync(() -> {
             String title = getUrlTitle(match);


### PR DESCRIPTION
如输入错误的的链接如https:www.baidu.com，后端正则只能匹配到www.baidu.com并且能够获取到链接标题，但是返回给前端的只有www.baidu.com，导致前端能正常显示url标题但是无法正常调整。所以后端在匹配url时直接排除不是htt://开头或者https://开头的，当然也可以在前端直接判断 看不懂vue3就不改了
![ed85d70101473dadc0f6a8839553aad](https://github.com/zongzibinbin/MallChat/assets/81894420/55ebf112-edc7-4e0c-82a6-1852103bbae9)

