### PR TITLE
去除Redis部分无效配置与依赖

### DIFF
--- a/mallchat-common/pom.xml
+++ b/mallchat-common/pom.xml
@@ -92,10 +92,6 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-redis</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
             <version>3.19.0</version>

--- a/mallchat-common/src/main/resources/application.yml
+++ b/mallchat-common/src/main/resources/application.yml
@@ -39,16 +39,6 @@ spring:
     timeout: 1800000
     # 设置密码
     password: ${mallchat.redis.password}
-    lettuce:
-      pool:
-        # 最大阻塞等待时间，负数表示没有限制
-        max-wait: -1
-        # 连接池中的最大空闲连接
-        max-idle: 5
-        # 连接池中的最小空闲连接
-        min-idle: 0
-        # 连接池中最大连接数，负数表示没有限制
-        max-active: 20
   jackson:
     serialization:
       write-dates-as-timestamps: true


### PR DESCRIPTION
1. 引入Redisson客户端会自动覆盖Luccuce客户端，因此Luttuce连接池配置无效
2. RedissonStarter依赖已依赖RedisStarter，且自动排除Jedis与Luttuce客户端依赖，无需在其他地方重复引入RedisStarer依赖