### PR TITLE
feat: 配置连接池, 异步多线程的MDC日志跟踪

### DIFF
--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/concurrent/MdcThreadPoolTaskExecutor.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/concurrent/MdcThreadPoolTaskExecutor.java
@@ -1,0 +1,83 @@
+package com.abin.mallchat.common.common.concurrent;
+
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.MDC;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+
+@Slf4j
+public class MdcThreadPoolTaskExecutor extends ThreadPoolTaskExecutor {
+
+
+    @Override
+    public void execute(@NotNull Runnable task) {
+        log.info("execute Runnable");
+        Map<String, String> context = MDC.getCopyOfContextMap();    //复制主线程MDC
+        super.execute(() -> {
+            if (null != context) {
+                MDC.setContextMap(context);     //主线程MDC赋予子线程
+            }
+            try {
+                task.run();
+            } finally {
+                try {
+                    MDC.clear();
+                } catch (Exception e) {
+                    log.warn("MDC clear exception：{}", e.getMessage());
+                }
+            }
+        });
+    }
+
+    @Override
+    @NotNull
+    public Future<?> submit(@NotNull Runnable task) {
+        log.info("submit Runnable");
+        Map<String, String> context = MDC.getCopyOfContextMap();
+        return super.submit(() -> {
+            if (null != context) {
+                MDC.setContextMap(context);     //主线程MDC赋予子线程
+            }
+            try {
+                task.run();
+            } finally {
+                try {
+                    MDC.clear();
+                } catch (Exception e) {
+                    log.warn("MDC clear exception：{}", e.getMessage());
+                }
+            }
+        });
+
+
+    }
+
+
+    /**
+     * 异步事件监听 会调用下述方法
+     */
+    @Override
+    @NotNull
+    public <T> Future<T> submit(@NotNull Callable<T> task) {
+        log.info("submit call");
+        Map<String, String> context = MDC.getCopyOfContextMap();
+        return super.submit(() -> {
+            if (null != context) {
+                MDC.setContextMap(context);     //主线程MDC赋予子线程
+            }
+            try {
+                return task.call();
+            } finally {
+                try {
+                    MDC.clear();
+                } catch (Exception e) {
+                    log.warn("MDC clear exception：{}", e.getMessage());
+                }
+            }
+        });
+    }
+}

--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/config/ThreadPoolConfig.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/config/ThreadPoolConfig.java
@@ -1,5 +1,6 @@
 package com.abin.mallchat.common.common.config;
 
+import com.abin.mallchat.common.common.concurrent.MdcThreadPoolTaskExecutor;
 import com.abin.mallchat.common.common.factory.MyThreadFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -38,7 +39,7 @@ public class ThreadPoolConfig implements AsyncConfigurer {
     @Bean(MALLCHAT_EXECUTOR)
     @Primary
     public ThreadPoolTaskExecutor mallchatExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        ThreadPoolTaskExecutor executor = new MdcThreadPoolTaskExecutor();
         executor.setCorePoolSize(10);
         executor.setMaxPoolSize(10);
         executor.setQueueCapacity(200);
@@ -51,7 +52,7 @@ public class ThreadPoolConfig implements AsyncConfigurer {
 
     @Bean(WS_EXECUTOR)
     public ThreadPoolTaskExecutor websocketExecutor() {
-        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        ThreadPoolTaskExecutor executor = new MdcThreadPoolTaskExecutor();
         executor.setCorePoolSize(16);
         executor.setMaxPoolSize(16);
         executor.setQueueCapacity(1000);//支持同时推送1000人
@@ -73,4 +74,5 @@ public class ThreadPoolConfig implements AsyncConfigurer {
         executor.setThreadFactory(new MyThreadFactory(executor));
         return executor;
     }
+
 }


### PR DESCRIPTION
之前在群里讨论时使用反射太过暴力,使用继承ThreadPoolTaskExecutor 重写方法, 修改子线程中MDC的ContextMap