### PR TITLE
优化：线程全局异常处理器改为单例模式

### DIFF
--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/factory/MyThreadFactory.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/factory/MyThreadFactory.java
@@ -15,7 +15,7 @@ public class MyThreadFactory  implements ThreadFactory {
     @Override
     public Thread newThread(Runnable r) {
         Thread thread =factory.newThread(r);
-        thread.setUncaughtExceptionHandler(new GlobalUncaughtExceptionHandler());
+        thread.setUncaughtExceptionHandler(GlobalUncaughtExceptionHandler.getInstance());
         return thread;
     }
 }

--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/handler/GlobalUncaughtExceptionHandler.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/handler/GlobalUncaughtExceptionHandler.java
@@ -5,10 +5,18 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class GlobalUncaughtExceptionHandler  implements Thread.UncaughtExceptionHandler {
 
+    private static final  GlobalUncaughtExceptionHandler instance = new GlobalUncaughtExceptionHandler();
+
+    private GlobalUncaughtExceptionHandler() {
+    }
 
     @Override
     public void uncaughtException(Thread t, Throwable e) {
         log.error("Exception in thread {} ", t.getName(), e);
+    }
+
+    public static GlobalUncaughtExceptionHandler getInstance() {
+        return instance;
     }
 
 }

--- a/mallchat-common/src/main/java/com/abin/mallchat/common/user/service/impl/IpServiceImpl.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/user/service/impl/IpServiceImpl.java
@@ -37,7 +37,7 @@ public class IpServiceImpl implements IpService, DisposableBean {
             0L, TimeUnit.MILLISECONDS,
             new LinkedBlockingQueue<>(500),
             new NamedThreadFactory("refresh-ipDetail", null, false,
-                    new GlobalUncaughtExceptionHandler()));
+                    GlobalUncaughtExceptionHandler.getInstance()));
 
     @Autowired
     private UserDao userDao;

--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/chat/service/impl/WeChatMsgOperationServiceImpl.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/chat/service/impl/WeChatMsgOperationServiceImpl.java
@@ -31,7 +31,7 @@ public class WeChatMsgOperationServiceImpl implements WeChatMsgOperationService 
             TimeUnit.MILLISECONDS,
             new LinkedBlockingQueue<Runnable>(20),
             new NamedThreadFactory("wechat-operation-thread", null, false,
-                    new GlobalUncaughtExceptionHandler()));
+                    GlobalUncaughtExceptionHandler.getInstance()));
 
     // at消息的微信推送模板id
     private final String atMsgPublishTemplateId = "Xd7sWPZsuWa0UmpvLaZPvaJVjNj1KjEa0zLOm5_Z7IU";


### PR DESCRIPTION
注意到每new一个线程时，都会创建一个新的全局异常处理器。身为一个 全局异常处理器 是不太合理的，故此改为单例模式实现