### PR TITLE
解决微信扫码回调和微信授权回调时，request和channel在不同服务器的问题:使用mq将消息利用广播模式让其他服务去处理

### DIFF
--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/constant/MQConstant.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/constant/MQConstant.java
@@ -16,4 +16,16 @@ public interface MQConstant {
      */
     String PUSH_TOPIC = "websocket_push";
     String PUSH_GROUP = "websocket_push_group";
+
+    /**
+     * (授权完成后)登录信息mq
+     */
+    String LOGIN_MSG_TOPIC = "login_send_msg";
+    String LOGIN_MSG_GROUP = "login_send_msg_group";
+
+    /**
+     * 扫码成功 信息发送mq
+     */
+    String SCAN_MSG_TOPIC = "scan_send_msg";
+    String SCAN_MSG_GROUP = "scan_send_msg_group";
 }

--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/constant/RedisKey.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/constant/RedisKey.java
@@ -59,6 +59,12 @@ public class RedisKey {
     public static final String USER_CHAT_CONTEXT = "useChatGPTContext:uid_%d_roomId_%d";
 
     /**
+     * 保存Open id
+     */
+    public static final String OPEN_ID_STRING = "openid:%s";
+
+
+    /**
      * 用户上次使用GLM使用时间
      */
     public static final String USER_GLM2_TIME_LAST = "userGLM2UseTime:uid_%d";

--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/domain/dto/LoginMessageDTO.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/domain/dto/LoginMessageDTO.java
@@ -1,0 +1,32 @@
+package com.abin.mallchat.common.common.domain.dto;
+
+import com.abin.mallchat.common.user.domain.enums.WSBaseResp;
+import com.abin.mallchat.common.user.domain.enums.WSPushTypeEnum;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import me.chanjar.weixin.mp.bean.message.WxMpXmlMessage;
+
+import java.io.Serializable;
+
+/**
+ * Description: 将扫码登录返回信息推送给所有横向扩展的服务
+ * Author: zjy
+ * Date: 2023-08-12
+ */
+@Data
+@NoArgsConstructor
+public class LoginMessageDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * 微信公众号获得扫码事件后,发送给我方的回调信息
+     */
+    private WxMpXmlMessage wxMpXmlMessage ;
+
+    public LoginMessageDTO(WxMpXmlMessage wxMpXmlMessage) {
+         this.wxMpXmlMessage = wxMpXmlMessage;
+    }
+
+}

--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/domain/dto/ScanSuccessMessageDTO.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/domain/dto/ScanSuccessMessageDTO.java
@@ -1,0 +1,33 @@
+package com.abin.mallchat.common.common.domain.dto;
+
+import com.abin.mallchat.common.user.domain.enums.WSBaseResp;
+import com.abin.mallchat.common.user.domain.enums.WSPushTypeEnum;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+/**
+ * Description: 扫码成功对象，推送给用户的消息对象
+ * Author: <a href="https://github.com/zongzibinbin">abin</a>
+ * Date: 2023-08-12
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ScanSuccessMessageDTO implements Serializable {
+    /**
+     * 推送的ws消息
+     */
+    private WSBaseResp<?> wsBaseMsg;
+    /**
+     * 推送的uid
+     */
+    private Integer loginCode;
+
+    public ScanSuccessMessageDTO(Integer loginCode, WSBaseResp<?> wsBaseMsg) {
+        this.loginCode = loginCode;
+        this.wsBaseMsg = wsBaseMsg;
+    }
+}

--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/utils/CacheHolder.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/utils/CacheHolder.java
@@ -1,0 +1,26 @@
+package com.abin.mallchat.common.common.utils;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import io.netty.channel.Channel;
+
+import java.time.Duration;
+
+/**
+ * Description: Cache管理器
+ * Author: <a href="https://github.com/zongzibinbin">abin</a>
+ * Date: 2023-04-05
+ */
+public class CacheHolder {
+
+    private static final Long MAX_MUM_SIZE = 10000L;
+
+    private static final Duration EXPIRE_TIME = Duration.ofHours(1);
+    /**
+     * 所有请求登录的code与channel关系
+     */
+    public static final Cache<Integer, Channel> WAIT_LOGIN_MAP = Caffeine.newBuilder()
+            .expireAfterWrite(EXPIRE_TIME)
+            .maximumSize(MAX_MUM_SIZE)
+            .build();
+}

--- a/mallchat-common/src/main/java/com/abin/mallchat/common/common/utils/RedisUtils.java
+++ b/mallchat-common/src/main/java/com/abin/mallchat/common/common/utils/RedisUtils.java
@@ -39,6 +39,22 @@ public class RedisUtils {
     }
 
     /**
+     * 自增int
+     *
+     * @param key  键
+     * @param time 时间(秒)
+     */
+    public static Integer integerInc(String key, int time, TimeUnit unit) {
+        RedisScript<Long> redisScript = new DefaultRedisScript<>(LUA_INCR_EXPIRE, Long.class);
+        Long result = stringRedisTemplate.execute(redisScript, Collections.singletonList(key), String.valueOf(unit.toSeconds(time)));
+        try{
+            return Integer.parseInt(result.toString());
+        }catch (Exception e) {
+            RedisUtils.del(key);
+            throw e;
+        }
+    }
+     /**
      * 指定缓存失效时间
      *
      * @param key  键
@@ -862,8 +878,8 @@ public class RedisUtils {
      * @param end
      * @return
      */
-    public static Set<ZSetOperations.TypedTuple<String>> zRangeWithScores(String key, long start,
-                                                                          long end) {
+    public static Set<TypedTuple<String>> zRangeWithScores(String key, long start,
+                                                           long end) {
         return stringRedisTemplate.opsForZSet().rangeWithScores(key, start, end);
     }
 

--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/consumer/MsgLoginConsumer.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/consumer/MsgLoginConsumer.java
@@ -1,0 +1,56 @@
+package com.abin.mallchat.custom.user.consumer;
+
+import com.abin.mallchat.common.common.constant.MQConstant;
+import com.abin.mallchat.common.common.constant.RedisKey;
+import com.abin.mallchat.common.common.domain.dto.LoginMessageDTO;
+import com.abin.mallchat.common.common.utils.CacheHolder;
+import com.abin.mallchat.common.user.dao.UserDao;
+import com.abin.mallchat.common.user.domain.entity.User;
+import com.abin.mallchat.custom.user.service.WebSocketService;
+import com.abin.mallchat.custom.user.service.WxMsgService;
+import io.netty.channel.Channel;
+import me.chanjar.weixin.mp.bean.message.WxMpXmlMessage;
+import org.apache.rocketmq.spring.annotation.MessageModel;
+import org.apache.rocketmq.spring.annotation.RocketMQMessageListener;
+import org.apache.rocketmq.spring.core.RocketMQListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+/**
+ * Description: 在本地服务上找寻对应channel，将对应用户登陆，并触发所有用户收到上线事件
+ * Author: <a href="https://github.com/zongzibinbin">abin</a>
+ * Date: 2023-08-12
+ */
+@RocketMQMessageListener(consumerGroup = MQConstant.LOGIN_MSG_GROUP, topic = MQConstant.LOGIN_MSG_TOPIC, messageModel = MessageModel.BROADCASTING)
+@Component
+public class MsgLoginConsumer implements RocketMQListener<LoginMessageDTO> {
+    @Autowired
+    private WxMsgService wxMsgService;
+    @Autowired
+    private UserDao userDao;
+
+    @Override
+    public void onMessage(LoginMessageDTO loginMessageDTO) {
+        WxMpXmlMessage wxMpXmlMessage = loginMessageDTO.getWxMpXmlMessage();
+        //给二维码绑定的登录code
+        Integer eventKey = Integer.parseInt(getEventKey(wxMpXmlMessage));
+        //本地未储存对应的channel,则结束
+        Channel channel = CacheHolder.WAIT_LOGIN_MAP.getIfPresent(eventKey);
+        if (Objects.isNull(channel)) {
+            return;
+        }
+        //查询openid对应的用户(必然存在)
+        String openid = wxMpXmlMessage.getFromUser();
+        User user = userDao.getByOpenId(openid);
+        //登录,并且清除缓存
+        wxMsgService.login(user.getId(), eventKey);
+    }
+
+    private String getEventKey(WxMpXmlMessage wxMpXmlMessage) {
+        //扫码关注的渠道事件有前缀，需要去除
+        return wxMpXmlMessage.getEventKey().replace("qrscene_", "");
+    }
+
+}

--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/consumer/ScanSuccessConsumer.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/consumer/ScanSuccessConsumer.java
@@ -1,0 +1,50 @@
+package com.abin.mallchat.custom.user.consumer;
+
+import cn.hutool.json.JSONUtil;
+import com.abin.mallchat.common.common.constant.MQConstant;
+import com.abin.mallchat.common.common.domain.dto.ScanSuccessMessageDTO;
+import com.abin.mallchat.common.common.utils.CacheHolder;
+import com.abin.mallchat.common.user.dao.UserDao;
+import com.abin.mallchat.common.user.domain.entity.User;
+import com.abin.mallchat.custom.user.service.WebSocketService;
+import com.abin.mallchat.custom.user.service.WxMsgService;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import me.chanjar.weixin.mp.bean.message.WxMpXmlMessage;
+import org.apache.rocketmq.spring.annotation.MessageModel;
+import org.apache.rocketmq.spring.annotation.RocketMQMessageListener;
+import org.apache.rocketmq.spring.core.RocketMQListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Objects;
+
+/**
+ * Description: 将扫码成功的信息发送给对应的用户,等待授权
+ * Author: <a href="https://github.com/zongzibinbin">abin</a>
+ * Date: 2023-08-12
+ */
+@RocketMQMessageListener(consumerGroup = MQConstant.SCAN_MSG_GROUP, topic = MQConstant.SCAN_MSG_TOPIC, messageModel = MessageModel.BROADCASTING)
+@Component
+public class ScanSuccessConsumer implements RocketMQListener<ScanSuccessMessageDTO> {
+    @Autowired
+    private WebSocketService webSocketService;
+    @Autowired
+    private WxMsgService wxMsgService;
+    @Autowired
+    private UserDao userDao;
+
+    @Override
+    public void onMessage(ScanSuccessMessageDTO scanSuccessMessageDTO) {
+        Integer loginCode = scanSuccessMessageDTO.getLoginCode();
+        //本地未储存对应的channel,则结束
+        Channel channel = CacheHolder.WAIT_LOGIN_MAP.getIfPresent(loginCode);
+        if (Objects.isNull(channel)) {
+            return;
+        }
+        //给正在等待登陆的channel发送扫码成功的消息，等待授权
+        channel.writeAndFlush(new TextWebSocketFrame(JSONUtil.toJsonStr(scanSuccessMessageDTO.getWsBaseMsg())));
+    }
+
+
+}

--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/service/UserService.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.abin.mallchat.custom.user.service;
 
 import com.abin.mallchat.common.user.domain.dto.ItemInfoDTO;
 import com.abin.mallchat.common.user.domain.dto.SummeryInfoDTO;
+import com.abin.mallchat.common.user.domain.entity.User;
 import com.abin.mallchat.custom.user.domain.vo.request.user.*;
 import com.abin.mallchat.custom.user.domain.vo.response.user.BadgeResp;
 import com.abin.mallchat.custom.user.domain.vo.response.user.UserInfoResp;
@@ -50,11 +51,11 @@ public interface UserService {
     void wearingBadge(Long uid, WearingBadgeReq req);
 
     /**
-     * 用户注册
+     * 用户注册，需要获得id
      *
-     * @param openId
+     * @param user
      */
-    void register(String openId);
+    void register(User user);
 
     void black(BlackReq req);
 

--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/service/WebSocketService.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/service/WebSocketService.java
@@ -36,7 +36,7 @@ public interface WebSocketService {
     void authorize(Channel channel, WSAuthorize wsAuthorize);
 
     /**
-     * 扫码用户登录成功通知
+     * 扫码用户登录成功通知,清除本地Cache中的loginCode和channel的关系
      *
      * @param loginCode
      * @param user
@@ -45,11 +45,11 @@ public interface WebSocketService {
     Boolean scanLoginSuccess(Integer loginCode, User user, String token);
 
     /**
-     * 用户扫码成功
+     * 通知用户扫码成功
      *
      * @param loginCode
      */
-    Boolean scanSuccess(Integer loginCode);
+    Boolean scanSuccess(Integer loginCode, Long uid);
 
     /**
      * 推动消息给所有在线的人

--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/service/WxMsgService.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/service/WxMsgService.java
@@ -1,10 +1,17 @@
 package com.abin.mallchat.custom.user.service;
 
 import cn.hutool.core.util.RandomUtil;
+import com.abin.mallchat.common.common.constant.MQConstant;
+import com.abin.mallchat.common.common.constant.RedisKey;
+import com.abin.mallchat.common.common.domain.dto.LoginMessageDTO;
+import com.abin.mallchat.common.common.utils.CacheHolder;
+import com.abin.mallchat.common.common.utils.RedisUtils;
 import com.abin.mallchat.common.user.dao.UserDao;
 import com.abin.mallchat.common.user.domain.entity.User;
 import com.abin.mallchat.custom.user.service.adapter.TextBuilder;
 import com.abin.mallchat.custom.user.service.adapter.UserAdapter;
+import com.abin.mallchat.transaction.service.MQProducer;
+import io.netty.channel.Channel;
 import lombok.extern.slf4j.Slf4j;
 import me.chanjar.weixin.common.bean.WxOAuth2UserInfo;
 import me.chanjar.weixin.mp.api.WxMpService;
@@ -21,6 +28,7 @@ import org.springframework.stereotype.Service;
 import java.net.URLEncoder;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Description: 处理与微信api的交互逻辑
@@ -48,25 +56,37 @@ public class WxMsgService {
     private UserService userService;
     @Autowired
     private ThreadPoolTaskExecutor threadPoolTaskExecutor;
-
+    @Autowired
+    private MQProducer mqProducer;
 
     public WxMpXmlOutMessage scan(WxMpService wxMpService, WxMpXmlMessage wxMpXmlMessage) {
-        String fromUser = wxMpXmlMessage.getFromUser();
-        Integer eventKey = Integer.parseInt(getEventKey(wxMpXmlMessage));
-        User user = userDao.getByOpenId(fromUser);
+        String openid = wxMpXmlMessage.getFromUser();
+        Integer loginCode = Integer.parseInt(getEventKey(wxMpXmlMessage));
+        User user = userDao.getByOpenId(openid);
+        //如果已经注册,直接登录成功
         if (Objects.nonNull(user) && StringUtils.isNotEmpty(user.getAvatar())) {
-            //注册且已经授权的用户，直接登录成功
-            login(user.getId(), eventKey);
+            Channel channel = CacheHolder.WAIT_LOGIN_MAP.getIfPresent(loginCode);
+            //要么在本地登录,否则利用mq广播到到所有服务上尝试登录
+            if (Objects.nonNull(channel)) {
+                String token = loginService.login(user.getId());
+                webSocketService.scanLoginSuccess(loginCode, user, token);
+            }else {
+                mqProducer.sendMsg(MQConstant.LOGIN_MSG_TOPIC, new LoginMessageDTO(wxMpXmlMessage));
+            }
             return null;
         }
+
+        //user为空先注册,手动生成,以保存uid
         if (Objects.isNull(user)) {
-            //未注册的先注册
-            userService.register(fromUser);
+            user = User.builder().openId(openid).build();
+            userService.register(user);
         }
-        //保存openid和场景code的关系，后续才能通知到前端
-        OPENID_EVENT_CODE_MAP.put(fromUser, eventKey);
-        //授权流程,给用户发送授权消息，并且异步通知前端扫码成功
-        threadPoolTaskExecutor.execute(() -> webSocketService.scanSuccess(eventKey));
+        Long uid = user.getId();
+
+        //在 redis中保存openid和场景code的关系，后续才能通知到前端,旧版数据没有清除,这里设置了过期时间
+        RedisUtils.set(RedisKey.getKey(RedisKey.OPEN_ID_STRING, openid), loginCode, 60, TimeUnit.MINUTES);
+        //授权流程,给用户发送授权消息，并且异步通知前端扫码成功(如非本地channel,使用MQ通知某服务对前端进行通知扫码成功)
+        threadPoolTaskExecutor.execute(() -> webSocketService.scanSuccess(loginCode, uid));
         String skipUrl = String.format(URL, wxMpService.getWxMpConfigStorage().getAppId(), URLEncoder.encode(callback + "/wx/portal/public/callBack"));
         WxMpXmlOutMessage.TEXT().build();
         return new TextBuilder().build("请点击链接授权：<a href=\"" + skipUrl + "\">登录</a>", wxMpXmlMessage, wxMpService);
@@ -88,9 +108,20 @@ public class WxMsgService {
         if (StringUtils.isEmpty(user.getName())) {
             fillUserInfo(user.getId(), userInfo);
         }
-        //触发用户登录成功操作
-        Integer eventKey = OPENID_EVENT_CODE_MAP.get(userInfo.getOpenid());
-        login(user.getId(), eventKey);
+        //找到对应的
+        Integer eventKey = RedisUtils.get(RedisKey.getKey(RedisKey.OPEN_ID_STRING, userInfo.getOpenid()), Integer.class);
+        //如果channel就在本地，直接登录
+        Channel channel = CacheHolder.WAIT_LOGIN_MAP.getIfPresent(eventKey);
+        if (Objects.nonNull(channel)) {
+            login(user.getId(), eventKey);
+        }else {
+            //如果channel不在本地，利用mq广播到到所有服务上,尝试进行登录
+            //手动生成一个WxMpXmlMessage
+            WxMpXmlMessage wxMpXmlMessage = new WxMpXmlMessage();
+            wxMpXmlMessage.setFromUser(userInfo.getOpenid());
+            wxMpXmlMessage.setEventKey("qrscene_"+eventKey);
+            mqProducer.sendMsg(MQConstant.LOGIN_MSG_TOPIC, new LoginMessageDTO(wxMpXmlMessage));
+        }
     }
 
     private void fillUserInfo(Long uid, WxOAuth2UserInfo userInfo) {
@@ -108,7 +139,7 @@ public class WxMsgService {
         }
     }
 
-    private void login(Long uid, Integer eventKey) {
+    public void login(Long uid, Integer eventKey) {
         User user = userDao.getById(uid);
         //调用用户登录模块
         String token = loginService.login(uid);

--- a/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/service/impl/UserServiceImpl.java
+++ b/mallchat-custom-server/src/main/java/com/abin/mallchat/custom/user/service/impl/UserServiceImpl.java
@@ -120,10 +120,9 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void register(String openId) {
-        User insert = User.builder().openId(openId).build();
-        userDao.save(insert);
-        applicationEventPublisher.publishEvent(new UserRegisterEvent(this, insert));
+    public void register(User user) {
+        userDao.save(user);
+        applicationEventPublisher.publishEvent(new UserRegisterEvent(this, user));
     }
 
     @Override


### PR DESCRIPTION
写的稍微有点乱，登录那块方法太多 跳的有点远，没动大的结构怕出意外。只进行本地测试，没有与前端联调测试（穿透等太花时间）。幸好是新版本，上之前需要联调测试一下