### PR TITLE
Fix an error in TextMsgHandler when setting the type of a reply

### DIFF
--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/chat/service/strategy/msg/TextMsgHandler.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/chat/service/strategy/msg/TextMsgHandler.java
@@ -120,7 +120,7 @@ public class TextMsgHandler extends AbstractMsgHandler {
             TextMsgResp.ReplyMsg replyMsgVO = new TextMsgResp.ReplyMsg();
             replyMsgVO.setId(replyMessage.getId());
             replyMsgVO.setUid(replyMessage.getFromUid());
-            replyMessage.setType(replyMessage.getType());
+            replyMsgVO.setType(replyMessage.getType());
             replyMsgVO.setBody(MsgHandlerFactory.getStrategyNoNull(replyMessage.getType()).showReplyMsg(replyMessage));
             User replyUser = userCache.getUserInfo(replyMessage.getFromUid());
             replyMsgVO.setUsername(replyUser.getName());


### PR DESCRIPTION
修复 TextMsgHandler 一处代码错误，这会导致返回前端的消息 的 回复消息的 type 为null。
在设置 回复消息 的 type时候，set 主体不应该是 replyMessage，而是 replyMsgVO。
