### PR TITLE
Fix 2 errors in TextMsgHandler and CheckRecall

### DIFF
--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/chat/service/impl/ChatServiceImpl.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/chat/service/impl/ChatServiceImpl.java
@@ -290,7 +290,7 @@ public class ChatServiceImpl implements ChatService {
 
     private void checkRecall(Long uid, Message message) {
         AssertUtil.isNotEmpty(message, "消息有误");
-        AssertUtil.notEqual(message.getType(), MessageTypeEnum.RECALL, "消息无法撤回");
+        AssertUtil.notEqual(message.getType(), MessageTypeEnum.RECALL.getType(), "消息无法撤回");
         boolean hasPower = iRoleService.hasPower(uid, RoleEnum.CHAT_MANAGER);
         if (hasPower) {
             return;

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/chat/service/strategy/msg/TextMsgHandler.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/chat/service/strategy/msg/TextMsgHandler.java
@@ -120,7 +120,7 @@ public class TextMsgHandler extends AbstractMsgHandler {
             TextMsgResp.ReplyMsg replyMsgVO = new TextMsgResp.ReplyMsg();
             replyMsgVO.setId(replyMessage.getId());
             replyMsgVO.setUid(replyMessage.getFromUid());
-            replyMessage.setType(replyMessage.getType());
+            replyMsgVO.setType(replyMessage.getType());
             replyMsgVO.setBody(MsgHandlerFactory.getStrategyNoNull(replyMessage.getType()).showReplyMsg(replyMessage));
             User replyUser = userCache.getUserInfo(replyMessage.getFromUid());
             replyMsgVO.setUsername(replyUser.getName());


### PR DESCRIPTION
1. 修复 TextMsgHandler 一处代码错误，这会导致返回的 回复消息 type 为null。在设置 回复消息 的 type时候，set 主体不应该是 replyMessage，而是 replyMsgVO。
2. 修复 CheckRecall 判断当前消息是否已经 被撤回，不应该将 Integer 与 MessageTypeEnum 进行比较，这样会一直返回 false。应该使用 MessageTypeEnum.RECALL.getType()