### PR TITLE
fix: 修复文本消息校验@用户的bug & 用户消息同步更新UserSummary

### DIFF
--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/user/service/cache/UserCache.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/user/service/cache/UserCache.java
@@ -39,6 +39,8 @@ public class UserCache {
     private RoleDao roleDao;
     @Autowired
     private UserRoleDao userRoleDao;
+    @Autowired
+    private UserSummaryCache userSummaryCache;
 
     public Long getOnlineNum() {
         String onlineKey = RedisKey.getKey(RedisKey.ONLINE_UID_ZET);
@@ -137,6 +139,8 @@ public class UserCache {
 
     public void userInfoChange(Long uid) {
         delUserInfo(uid);
+        //删除UserSummaryCache，前端下次懒加载的时候可以获取到最新的数据
+        userSummaryCache.delete(uid);
         refreshUserModifyTime(uid);
     }
 


### PR DESCRIPTION
1. 前端 一条文本中@同一个人两次，atUidList 会有两个相同的uid。后端校验@用户是否存在的时候，cache返回Map<Long, User> batch 只有一条数据，导致校验失败。**因此需要先去重 后校验**<img width="600" alt="image" src="https://github.com/zongzibinbin/MallChat/assets/49775184/b74af23e-d428-481b-9a06-d24483f401f8">
2. 如果 atUidList 中有不存在的用户，后端校验@用户是否存在的时候 cache返回Map<Long, User> batch 仍然会有 不存在用户的entry，但是value为null。但是目前校验方式是判断size是否一致，因此**需要去除batch中的null以后再校验**<img width="500" alt="image" src="https://github.com/zongzibinbin/MallChat/assets/49775184/09552d1d-a74f-4883-97fd-eeb2274ab1a5">
3. 在更新 用户信息的时候（如改名），应该**删除 UserSummary 缓存**。不然前端下次懒加载 + UserSummary没过期，返回数据还是没有更新。原代码中更新了 modifyTime，一定会触发下次前端的懒加载，UserSummary 也要是最新的。




