### PR TITLE
fix：SecureInvoke注解同步出现bug

### DIFF
--- a/mallchat-tools/mallchat-transaction/src/main/java/com/abin/mallchat/transaction/service/SecureInvokeService.java
+++ b/mallchat-tools/mallchat-transaction/src/main/java/com/abin/mallchat/transaction/service/SecureInvokeService.java
@@ -83,12 +83,15 @@ public class SecureInvokeService {
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @SneakyThrows
             @Override
-            public void afterCommit() {
-                //事务后执行
-                if (async) {
-                    doAsyncInvoke(record);
-                } else {
-                    doInvoke(record);
+            public void afterCompletion(int status) {
+                if (status==TransactionSynchronization.STATUS_COMMITTED){
+                    TransactionSynchronizationManager.clear();
+                    if (async){
+                        //事务后执行
+                        doAsyncInvoke(record);
+                    } else {
+                        doInvoke(record);
+                    }
                 }
             }
         });


### PR DESCRIPTION
1. 当SecureInvoke注解实现`同步`执行的时候， **在执行反射的时候第二次进入切面，还处于事务当中** ，这样不但不会执行方法，本地消息表还会多一条记录。（在执行异步的时候由于不是一个线程，所以不会出现此问题）
2. TransactionSynchronizationManager维护了很多ThreadLocal
![输入图片说明](https://foruda.gitee.com/images/1695045892702854038/465c11a5_11870029.png "屏幕截图")
3. TransactionSynchronizationManager里面提供了静态方法clear(),所以在确定事务提交之后手动调用此方法即可

```
TransactionSynchronizationManager.registerSynchronization(
    new TransactionSynchronization() {
        @SneakyThrows
        @Override
        public void afterCompletion(int status) {
            if (status==TransactionSynchronization.STATUS_COMMITTED){
                //事务成功提交，手动清理ThreadLocal
                TransactionSynchronizationManager.clear();
                //事务后执行
                if (async) {
                    doAsyncInvoke(record);
                } else {
                    doInvoke(record);
                }
            }
        }
     });
```
