### PR TITLE
【优化】优化AC自动机敏感词过滤

### DIFF
--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/chat/service/strategy/msg/TextMsgHandler.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/chat/service/strategy/msg/TextMsgHandler.java
@@ -14,7 +14,7 @@ import com.abin.mallchat.common.common.domain.enums.YesOrNoEnum;
 import com.abin.mallchat.common.common.utils.AssertUtil;
 import com.abin.mallchat.common.common.utils.discover.PrioritizedUrlDiscover;
 import com.abin.mallchat.common.common.utils.discover.domain.UrlInfo;
-import com.abin.mallchat.common.common.utils.sensitiveWord.SensitiveWordBs;
+import com.abin.mallchat.common.common.algorithm.sensitiveWord.SensitiveWordBs;
 import com.abin.mallchat.common.user.domain.entity.User;
 import com.abin.mallchat.common.user.domain.enums.RoleEnum;
 import com.abin.mallchat.common.user.service.IRoleService;

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/acpro/ACProTrie.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/acpro/ACProTrie.java
@@ -1,0 +1,141 @@
+package com.abin.mallchat.common.common.algorithm.acpro;
+
+import java.util.*;
+
+/**
+ *@author CtrlCver
+ *@date 2024/1/12
+ *@description:  AC自动机
+ */
+public class ACProTrie {
+
+    private final static char MASK = '*'; // 替代字符
+
+    private  Word  root;
+
+    // 节点
+    static class Word{
+        // 判断是否是敏感词结尾
+        boolean end=false;
+        // 失败回调节点/状态
+        Word failOver=null;
+        // 记录字符偏移
+        int depth=0;
+        // 下个自动机状态
+        Map<Character,Word> next=new HashMap<>();
+        public boolean hasChild(char c) {
+            return next.containsKey(c);
+        }
+    }
+    //构建ACTrie
+    public   void createACTrie(List<String> list){
+        Word currentNode = new Word();
+        root=currentNode;
+        for(String key : list)
+        {
+            currentNode=root;
+            for(int j=0;j<key.length();j++)
+            {
+                if(currentNode.next!=null&&currentNode.next.containsKey(key.charAt(j))){
+                    currentNode= currentNode.next.get(key.charAt(j));
+                    // 防止乱序输入改变end,比如da，dadac，dadac先进入，第二个a为false,da进入后把a设置为true
+                    // 这样结果就是a是end，c也是end
+                    if(j==key.length()-1){
+                        currentNode.end=true;
+                    }
+                }else {
+                    Word map = new Word();
+                    if(j==key.length()-1){
+                        map.end=true;
+                    }
+                    currentNode.next.put(key.charAt(j), map);
+                    currentNode=map;
+                }
+                currentNode.depth = j+1;
+            }
+        }
+        initFailOver();
+    }
+    // 初始化匹配失败回调节点/状态
+    public  void initFailOver(){
+        Queue<Word> queue=new LinkedList<>();
+        Map<Character,Word> children=root.next;
+        for(Word node:children.values())
+        {
+            node.failOver=root;
+            queue.offer(node);
+        }
+        while(!queue.isEmpty())
+        {
+            Word parentNode=queue.poll();
+            for(Map.Entry<Character,Word> entry:parentNode.next.entrySet())
+            {
+                Word childNode=entry.getValue();
+                Word failOver=parentNode.failOver;
+                while(failOver!=null&&(!failOver.next.containsKey(entry.getKey()))){
+                    failOver=failOver.failOver;
+                }
+                if(failOver==null){
+                    childNode.failOver=root;
+                }else{
+                    childNode.failOver=failOver.next.get(entry.getKey());
+                }
+                queue.offer(childNode);
+            }
+        }
+    }
+    // 匹配
+    public  String match(String matchWord)
+    {
+        Word walkNode=root;
+        char[] wordArray=matchWord.toCharArray();
+        for(int i=0;i<wordArray.length;i++)
+        {
+            // 失败回调状态
+            while(!walkNode.hasChild(wordArray[i]) && walkNode.failOver!=null)
+            {
+                walkNode=walkNode.failOver;
+            }
+            if(walkNode.hasChild(wordArray[i])) {
+                walkNode=walkNode.next.get(wordArray[i]);
+                if(walkNode.end){
+                    // sentinelA和sentinelB作为哨兵节点，去后面探测是否仍存在end
+                    Word sentinelA = walkNode; // 记录当前节点
+                    Word sentinelB = walkNode; //记录end节点
+                    int k = i+1;
+                    boolean flag=false;
+                    //判断end是不是最终end即敏感词是否存在包含关系(abc,abcd)
+                    while(k < wordArray.length && sentinelA.hasChild(wordArray[k])) {
+                        sentinelA = sentinelA.next.get(wordArray[k]);
+                        k++;
+                        if(sentinelA.end)
+                        {
+                            sentinelB=sentinelA;
+                            flag=true;
+                        }
+                    }
+                    // 根据结果去替换*
+                    if(flag){
+                        int length=sentinelB.depth;
+                        while(length>0)
+                        {
+                            length--;
+                            wordArray[i+length]=MASK;
+                        }
+                        // 直接跳到最后的end节点failOver
+                        i=i+length;
+                        walkNode = sentinelB.failOver;
+                    }else{
+                        int length=walkNode.depth;
+                        while (length>0){
+                            length--;
+                            wordArray[i-length]=MASK;
+                        }
+                        walkNode = walkNode.failOver;
+                    }
+                }
+            }
+        }
+        return new String(wordArray);
+    }
+}

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/ACFilter.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/ACFilter.java
@@ -1,4 +1,4 @@
-package com.abin.mallchat.common.common.utils.sensitiveWord;
+package com.abin.mallchat.common.common.algorithm.sensitiveWord;
 
 import com.abin.mallchat.common.common.algorithm.ac.ACTrie;
 import com.abin.mallchat.common.common.algorithm.ac.MatchResult;

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/ACProFilter.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/ACProFilter.java
@@ -1,0 +1,35 @@
+package com.abin.mallchat.common.common.algorithm.sensitiveWord;
+
+import com.abin.mallchat.common.common.algorithm.ac.ACTrie;
+import com.abin.mallchat.common.common.algorithm.acpro.ACProTrie;
+import io.micrometer.core.instrument.util.StringUtils;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ *@author CtrlCver
+ *@date 2024/1/12
+ *@description:  基于ACFilter的优化增强版本
+ */
+public class ACProFilter implements SensitiveWordFilter{
+    private ACProTrie acProTrie;
+
+    @Override
+    public boolean hasSensitiveWord(String text) {
+        if(StringUtils.isBlank(text)) return false;
+        return !Objects.equals(filter(text),text);
+    }
+
+    @Override
+    public String filter(String text) {
+        return acProTrie.match(text);
+    }
+
+    @Override
+    public void loadWord(List<String> words) {
+        if (words == null) return;
+        acProTrie = new ACProTrie();
+        acProTrie.createACTrie(words);
+    }
+}

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/DFAFilter.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/DFAFilter.java
@@ -1,4 +1,4 @@
-package com.abin.mallchat.common.common.utils.sensitiveWord;
+package com.abin.mallchat.common.common.algorithm.sensitiveWord;
 
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.util.CollectionUtils;

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/IWordFactory.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/IWordFactory.java
@@ -1,4 +1,4 @@
-package com.abin.mallchat.common.common.utils.sensitiveWord;
+package com.abin.mallchat.common.common.algorithm.sensitiveWord;
 
 import java.util.List;
 

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/SensitiveWordBs.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/SensitiveWordBs.java
@@ -1,4 +1,4 @@
-package com.abin.mallchat.common.common.utils.sensitiveWord;
+package com.abin.mallchat.common.common.algorithm.sensitiveWord;
 
 import java.util.List;
 

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/SensitiveWordFilter.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/algorithm/sensitiveWord/SensitiveWordFilter.java
@@ -1,4 +1,4 @@
-package com.abin.mallchat.common.common.utils.sensitiveWord;
+package com.abin.mallchat.common.common.algorithm.sensitiveWord;
 
 
 import java.util.List;

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/config/SensitiveWordConfig.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/config/SensitiveWordConfig.java
@@ -1,7 +1,7 @@
 package com.abin.mallchat.common.common.config;
 
-import com.abin.mallchat.common.common.utils.sensitiveWord.DFAFilter;
-import com.abin.mallchat.common.common.utils.sensitiveWord.SensitiveWordBs;
+import com.abin.mallchat.common.common.algorithm.sensitiveWord.DFAFilter;
+import com.abin.mallchat.common.common.algorithm.sensitiveWord.SensitiveWordBs;
 import com.abin.mallchat.common.sensitive.MyWordFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/sensitive/MyWordFactory.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/sensitive/MyWordFactory.java
@@ -1,6 +1,6 @@
 package com.abin.mallchat.common.sensitive;
 
-import com.abin.mallchat.common.common.utils.sensitiveWord.IWordFactory;
+import com.abin.mallchat.common.common.algorithm.sensitiveWord.IWordFactory;
 import com.abin.mallchat.common.sensitive.dao.SensitiveWordDao;
 import com.abin.mallchat.common.sensitive.domain.SensitiveWord;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/user/service/impl/UserServiceImpl.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/user/service/impl/UserServiceImpl.java
@@ -4,7 +4,7 @@ import cn.hutool.core.util.StrUtil;
 import com.abin.mallchat.common.common.event.UserBlackEvent;
 import com.abin.mallchat.common.common.event.UserRegisterEvent;
 import com.abin.mallchat.common.common.utils.AssertUtil;
-import com.abin.mallchat.common.common.utils.sensitiveWord.SensitiveWordBs;
+import com.abin.mallchat.common.common.algorithm.sensitiveWord.SensitiveWordBs;
 import com.abin.mallchat.common.user.dao.BlackDao;
 import com.abin.mallchat.common.user.dao.ItemConfigDao;
 import com.abin.mallchat.common.user.dao.UserBackpackDao;

--- a/mallchat-chat-server/src/test/java/com/abin/mallchat/common/SensitiveTest.java
+++ b/mallchat-chat-server/src/test/java/com/abin/mallchat/common/SensitiveTest.java
@@ -1,11 +1,13 @@
 package com.abin.mallchat.common;
 
-import com.abin.mallchat.common.common.utils.sensitiveWord.ACFilter;
-import com.abin.mallchat.common.common.utils.sensitiveWord.DFAFilter;
+import com.abin.mallchat.common.common.algorithm.sensitiveWord.ACFilter;
+import com.abin.mallchat.common.common.algorithm.sensitiveWord.ACProFilter;
+import com.abin.mallchat.common.common.algorithm.sensitiveWord.DFAFilter;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.util.*;
 
 /**
  * Description:
@@ -21,6 +23,7 @@ public class SensitiveTest {
         System.out.println(instance.hasSensitiveWord("adabcd"));
     }
 
+
     @Test
     public void AC() {
         List<String> sensitiveList = Arrays.asList("abcd", "abcbba", "adabca");
@@ -29,6 +32,14 @@ public class SensitiveTest {
         instance.hasSensitiveWord("adabcd");
     }
 
+    @Test
+    public void ACPro()
+    {
+        List<String> sensitiveList = Arrays.asList("白痴", "你是白痴", "白痴吗");
+        ACProFilter acProFilter=new ACProFilter();
+        acProFilter.loadWord(sensitiveList);
+        System.out.println(acProFilter.filter("你是白痴吗"));
+    }
     @Test
     public void DFAMulti() {
         List<String> sensitiveList = Arrays.asList("白痴", "你是白痴", "白痴吗");


### PR DESCRIPTION
## 文件准备

我把项目中的ACFilter,DFAFilter和其相关类文件,拷贝下来，删除了接口实现，其他原封不动

我自己写的是ACProFilter，
![image](https://github.com/zongzibinbin/MallChat/assets/95746922/10876981-2016-4ee4-87f7-dc29d4510a1c)
验证代码在MainTest类中：
```java
public class TestMain {
    public static void main(String[] args) {
        DFA dfa=DFA.getInstance();
        AC ac=new AC();
        ACPro acPro=new ACPro();

        List<String> list = new ArrayList<>();
        try {
            BufferedReader in = new BufferedReader(new FileReader("SensitiveWordList.txt"));
            String str;
            while ((str = in.readLine()) != null) {
                list.add(str);
            }
        }catch (Exception e){
            System.out.println("----------------敏感词库加载失败------------------");
        }
        System.out.println("----------------敏感词库已加载:"+list.size()+"------------------");

        dfa.loadWord(list);
        ac.loadWord(list);
        acPro.loadWord(list);
        long start;
        long end;
        String test1="abcdefg";
        String result="";
        System.out.println(test1);
        start=System.nanoTime();
        for (int i = 0; i < 100000; i++) {
            result=acPro.filter(test1);
        }
        end=System.nanoTime();
        System.out.print((end-start));
        System.out.println(" ACPro   "+result);
//        start=System.nanoTime();
//        result=ac.filter(test1);
//        end=System.nanoTime();
//        System.out.print((end-start));
//        System.out.println(" AC   "+result);
//        start=System.nanoTime();
//        result=acPro.filter(test1);
//        end=System.nanoTime();
//        System.out.print((end-start));
//        System.out.println(" ACPro   "+result);
}
```
## 测试思路

刚开始是三个filter依次运行打印结果和时间并且是单次执行，但是发现执行顺序对结果影响较大，第一个运行的较慢，然后又先循环10次进行预热处理，后面再依次运行发现次序差异依旧很大，分析可能是因为热点代码的问题。最终决定单个执行，for循环10万次，输出总用时，每次保证敏感词相同，三个fiter都初始化，每次调用只改变for循环执行的filter，其他全部不变。

## 执行结果和截图

> 所有词库均隔离

1. 预设过滤敏感词：babac
   待匹配字符串： bababac

   耗时比：6：10：3

| filter | 时间 / 纳秒ns | 结果     | 次数    |
| ------ | ------------- | -------- | ------- |
| DFA    | 6161_2600     | 完全匹配 | 10_0000 |
| AC     | 10201_2600    | 完全匹配 | 10_0000 |
| ACPro  | 2733_2900     | 完全匹配 | 10_0000 |

![image](https://github.com/zongzibinbin/MallChat/assets/95746922/28e2241c-5fde-4247-a1ed-798ca32d2307)
![image](https://github.com/zongzibinbin/MallChat/assets/95746922/09b98004-d214-4ea0-bd6e-af3d87842040)
![image](https://github.com/zongzibinbin/MallChat/assets/95746922/29ef7d27-5930-465a-b28d-ba4f10a6b623)

2.预设过滤敏感词：abcde || dem 

  待匹配字符串： abcdem

  耗时比： 5：9：3

| filter | 时间 / 纳秒ns | 结果      | 次数    |
| ------ | ------------- | --------- | ------- |
| DFA    | 5468_2700     | m未被替换 | 10_0000 |
| AC     | 8845_8000     | 完全匹配  | 10_0000 |
| ACPro  | 3160_5800     | 完全匹配  | 10_0000 |

![image](https://github.com/zongzibinbin/MallChat/assets/95746922/25586267-ed74-4c6b-98b9-62ffa176d0c8)
![image](https://github.com/zongzibinbin/MallChat/assets/95746922/c51e1878-4e74-4145-92ec-73dc4bfb5713)
![image](https://github.com/zongzibinbin/MallChat/assets/95746922/e52e49c9-c5bf-47ac-9c4f-b695bc1889fe)

3.预设过滤敏感词：abcde || abc 

  待匹配字符串： abcde

  耗时比： 4：8：3

| filter | 时间 / 纳秒ns | 结果       | 次数    |
| ------ | ------------- | ---------- | ------- |
| DFA    | 4250_2200     | 完全匹配   | 10_0000 |
| AC     | 7947_7800     | de未被替换 | 10_0000 |
| ACPro  | 2763_5100     | 完全匹配   | 10_0000 |

![image](https://github.com/zongzibinbin/MallChat/assets/95746922/f330ebdb-053b-452b-a4d6-9682c904fb18)
![image](https://github.com/zongzibinbin/MallChat/assets/95746922/43ced163-8033-42eb-929b-b8baa2c0e14e)
![image](https://github.com/zongzibinbin/MallChat/assets/95746922/2f5020b4-6c16-44fb-a626-f2f8f8ccee70)

## 总结

   将三组实两两对比不难得出下列结论：

   对于abcde|| dem这种首位嵌套的敏感词组，DFA方法只能匹配到abcde即"首"类型，而AC和ACPro均能全部判断出，并且这两种方法耗时都小于DFA，但ACPro方法明显耗时更短；
   对于abcde||abc这种具有包含关系的敏感词组，AC只能识别出最短的即abc，de无法过滤，但是ACPro和DFA均能全部判断，但ACPro方法明显耗时更短：

   ACPro匹配精度更高100%（可以看算法分析验证），而AC和DFA君会对特定场景局部失效；同时ACPro效率更高，性能提升2~3倍左右。
  （原来本地全是static方法，较快一点，匹配两个字的敏感词速度单次运行能夸张到1000多ns）





