### PR TITLE
add. 增加全局请求体包装

### DIFF
--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/config/BaseResponseAdvice.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/config/BaseResponseAdvice.java
@@ -1,0 +1,68 @@
+package com.abin.mallchat.common.common.config;
+
+import com.abin.mallchat.common.common.domain.vo.response.ApiResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+/**
+ * @Author HuaPai
+ * @Email flowercard591@gmail.com
+ * @Date 2024/1/22 11:39
+ * @Description 统一响应体
+ */
+@RestControllerAdvice(basePackages = "com.abin.mallchat")
+public class BaseResponseAdvice implements ResponseBodyAdvice<Object> {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        Class<?> parameterType = returnType.getParameterType();
+        return !parameterType.isAssignableFrom(ResponseEntity.class);
+    }
+
+    /**
+     * 响应体重写
+     * @param body                  响应体
+     * @param returnType            返回类型
+     * @param selectedContentType   选择的内容类型
+     * @param selectedConverterType 选择的转换类型
+     * @param request               请求
+     * @param response              响应
+     * @return                     响应体
+     */
+    @SneakyThrows
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+
+        // 原始类型就直接返回
+        if (body instanceof ApiResult) {
+            return body;
+        }
+
+        if (body instanceof String) {
+            // String 类型需要重置响应体为 Json 格式
+            response.getHeaders().setContentType(MediaType.APPLICATION_JSON);
+            return objectMapper.writeValueAsString(
+                    ApiResult.success(body)
+            );
+        }
+
+        return ApiResult.success(body);
+    }
+}

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/config/JacksonConfig.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/config/JacksonConfig.java
@@ -1,0 +1,158 @@
+package com.abin.mallchat.common.common.config;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.TimeZone;
+
+import javax.validation.constraints.NotNull;
+
+import com.abin.mallchat.common.common.deserializer.MyBeanSerializerModifier;
+import com.abin.mallchat.common.common.enums.SerializerFeature;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
+
+/**
+ * @Author HuaPai
+ * @Email flowercard591@gmail.com
+ * @Date 2024/01/22 12:28
+ * @Description Jackson配置
+ */
+@Configuration
+public class JacksonConfig {
+    /**
+     * 默认日期时间格式
+     */
+    public static final String DEFAULT_DATE_TIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+    /**
+     * 默认日期格式
+     */
+    public static final String DEFAULT_DATE_FORMAT = "yyyy-MM-dd";
+    /**
+     * 默认时间格式
+     */
+    public static final String DEFAULT_TIME_FORMAT = "HH:mm:ss";
+
+    @ConditionalOnMissingBean
+    @Bean
+    public MappingJackson2HttpMessageConverter mappingJacksonHttpMessageConverter() {
+        final MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
+        converter.setObjectMapper(objectMapper());
+        converter.setSupportedMediaTypes(Arrays.asList(MediaType.APPLICATION_JSON, MediaType.APPLICATION_OCTET_STREAM));
+        return converter;
+    }
+
+
+    @ConditionalOnMissingBean
+    @Bean("objectMapper")
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+
+        //LocalDateTime系列序列化和反序列化模块，继承自jsr310，我们在这里修改了日期格式
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+        javaTimeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_FORMAT)));
+        javaTimeModule.addSerializer(LocalDate.class, new LocalDateSerializer(DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT)));
+        javaTimeModule.addSerializer(LocalTime.class, new LocalTimeSerializer(DateTimeFormatter.ofPattern(DEFAULT_TIME_FORMAT)));
+        javaTimeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_FORMAT)));
+        javaTimeModule.addDeserializer(LocalDate.class, new LocalDateDeserializer(DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT)));
+        javaTimeModule.addDeserializer(LocalTime.class, new LocalTimeDeserializer(DateTimeFormatter.ofPattern(DEFAULT_TIME_FORMAT)));
+
+        //Date序列化和反序列化
+        // 指定时区
+        objectMapper.setTimeZone(TimeZone.getTimeZone("GMT+8:00"));
+        // 日期类型字符串处理
+        objectMapper.setDateFormat(new SimpleDateFormat(DEFAULT_DATE_TIME_FORMAT));
+        //小long不参与序列化成str
+        javaTimeModule.addSerializer(Long.class, ToStringSerializer.instance);
+        SimpleModule module = new SimpleModule();
+        // 枚举序列化器
+        //module.addDeserializer(Enum.class, new EnumDeserializer());
+        objectMapper.registerModules(javaTimeModule, module);
+
+        // 为objectMapper注册一个带有SerializerModifier的Factory，此modifier主要做的事情为：当序列化类型为array，list、set时，当值为空时，序列化成[]
+        objectMapper.setSerializerFactory(objectMapper.getSerializerFactory().withSerializerModifier(new MyBeanSerializerModifier(SerializerFeature.WriteNullListAsEmpty,
+                SerializerFeature.WriteNullStringAsEmpty/*, SerializerFeature.WriteNullNumberAsZero*/))).configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return objectMapper;
+    }
+
+    /**
+     * LocalDate转换器，用于转换RequestParam和PathVariable参数
+     */
+    @Bean
+    public Converter<String, LocalDate> localDateConverter() {
+        return new Converter<String, LocalDate>() {
+            @Override
+            public LocalDate convert(@NotNull String source) {
+                return LocalDate.parse(source, DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT));
+            }
+        };
+    }
+
+    /**
+     * LocalDateTime转换器，用于转换RequestParam和PathVariable参数
+     */
+    @Bean
+    public Converter<String, LocalDateTime> localDateTimeConverter() {
+        return new Converter<String, LocalDateTime>() {
+            @Override
+            public LocalDateTime convert(@NotNull String source) {
+                return LocalDateTime.parse(source, DateTimeFormatter.ofPattern(DEFAULT_DATE_TIME_FORMAT));
+            }
+        };
+    }
+
+    /**
+     * LocalTime转换器，用于转换RequestParam和PathVariable参数
+     */
+    @Bean
+    public Converter<String, LocalTime> localTimeConverter() {
+        return new Converter<String, LocalTime>() {
+            @Override
+            public LocalTime convert(@NotNull String source) {
+                return LocalTime.parse(source, DateTimeFormatter.ofPattern(DEFAULT_TIME_FORMAT));
+            }
+        };
+    }
+
+    /**
+     * Date转换器，用于转换RequestParam和PathVariable参数
+     */
+    @Bean
+    public Converter<String, Date> dateConverter() {
+        return new Converter<String, Date>() {
+            @Override
+            public Date convert(@NotNull String source) {
+                SimpleDateFormat format = new SimpleDateFormat(DEFAULT_DATE_TIME_FORMAT);
+                try {
+                    return format.parse(source);
+                } catch (ParseException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        };
+    }
+}

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/deserializer/MyBeanSerializerModifier.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/deserializer/MyBeanSerializerModifier.java
@@ -1,0 +1,89 @@
+package com.abin.mallchat.common.common.deserializer;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+
+import com.abin.mallchat.common.common.enums.SerializerFeature;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.*;
+import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
+import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
+
+/**
+ * @Author HuaPai
+ * @Email flowercard591@gmail.com
+ * @Date 2024/1/22 12:43
+ */
+public class MyBeanSerializerModifier extends BeanSerializerModifier {
+
+	final private JsonSerializer<Object> nullBooleanJsonSerializer;
+	final private JsonSerializer<Object> nullNumberJsonSerializer;
+	final private JsonSerializer<Object> nullListJsonSerializer;
+	final private JsonSerializer<Object> nullStringJsonSerializer;
+
+	public MyBeanSerializerModifier(SerializerFeature... features) {
+		int config = 0;
+		for (SerializerFeature feature : features) {
+			config |= feature.mask;
+		}
+		nullBooleanJsonSerializer = (config & SerializerFeature.WriteNullBooleanAsFalse.mask) != 0 ? new NullBooleanSerializer() : null;
+		nullNumberJsonSerializer = (config & SerializerFeature.WriteNullNumberAsZero.mask) != 0 ? new NullNumberSerializer() : null;
+		nullListJsonSerializer = (config & SerializerFeature.WriteNullListAsEmpty.mask) != 0 ? new NullListJsonSerializer() : null;
+		nullStringJsonSerializer = (config & SerializerFeature.WriteNullStringAsEmpty.mask) != 0 ? new NullStringSerializer() : null;
+	}
+
+	private static class NullListJsonSerializer extends JsonSerializer<Object> {
+		@Override
+		public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+			jgen.writeStartArray();
+			jgen.writeEndArray();
+		}
+	}
+
+	private static class NullNumberSerializer extends JsonSerializer<Object> {
+		@Override
+		public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+			jgen.writeNumber(0);
+		}
+	}
+
+	private static class NullBooleanSerializer extends JsonSerializer<Object> {
+		@Override
+		public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+			jgen.writeBoolean(false);
+		}
+	}
+
+	private static class NullStringSerializer extends JsonSerializer<Object> {
+		@Override
+		public void serialize(Object value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+			jgen.writeString("");
+		}
+	}
+
+	@Override
+	public List<BeanPropertyWriter> changeProperties(SerializationConfig config, BeanDescription beanDesc,
+			List<BeanPropertyWriter> beanProperties) {
+		for (BeanPropertyWriter writer : beanProperties) {
+			final JavaType javaType = writer.getType();
+			final Class<?> rawClass = javaType.getRawClass();
+			if (javaType.isArrayType() || javaType.isCollectionLikeType()) {
+				writer.assignNullSerializer(nullListJsonSerializer);
+			} else if (Number.class.isAssignableFrom(rawClass) && rawClass.getName().startsWith("java.lang")) {
+				writer.assignNullSerializer(nullNumberJsonSerializer);
+			} else if (Boolean.class.equals(rawClass)) {
+				writer.assignNullSerializer(nullBooleanJsonSerializer);
+			} else if (String.class.equals(rawClass)) {
+				writer.assignNullSerializer(nullStringJsonSerializer);
+			} else if (LocalDateTime.class.equals(rawClass)){
+				writer.assignNullSerializer(nullStringJsonSerializer);
+			} else if (Date.class.equals(rawClass)){
+				writer.assignNullSerializer(nullStringJsonSerializer);
+			}
+		}
+		return beanProperties;
+	}
+
+}

--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/enums/SerializerFeature.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/enums/SerializerFeature.java
@@ -1,0 +1,16 @@
+package com.abin.mallchat.common.common.enums;
+
+/**
+ * @Author HuaPai
+ * @Email flowercard591@gmail.com
+ * @Date 2024/01/22 12:28
+ */
+public enum SerializerFeature {
+	WriteNullListAsEmpty, WriteNullStringAsEmpty, WriteNullNumberAsZero, WriteNullBooleanAsFalse;
+
+	public final int mask;
+
+	SerializerFeature() {
+		mask = (1 << ordinal());
+	}
+}


### PR DESCRIPTION
接口中的 controller 接口每次返回都要声明一次顶层返回体包装类。通过实现 `ResponseBodyAdvice ` 可以对返回的内容进行统一包装，controller 接口返回 data 的结果即可
示例代码如下：
```java
    /**
     * 测试
     * @return 测试
     */
    @ApiOperation("测试")
    @GetMapping("/public/test")
    public String test() {
        return "test";
    }

    /**
     * 测试
     * @return 测试
     */
    @ApiOperation("测试")
    @GetMapping("/public/test2")
    public ApiResult<String> test2() {
        return ApiResult.success("test2");
    }
```