### PR TITLE
fix:修复本地环境下Redis密码为空启动报错

### DIFF
--- a/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/config/RedissonConfig.java
+++ b/mallchat-chat-server/src/main/java/com/abin/mallchat/common/common/config/RedissonConfig.java
@@ -1,8 +1,10 @@
 package com.abin.mallchat.common.common.config;
 
+import cn.hutool.core.util.StrUtil;
 import org.redisson.Redisson;
 import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
+import org.redisson.spring.starter.RedissonAutoConfigurationCustomizer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
@@ -23,8 +25,13 @@ public class RedissonConfig {
         Config config = new Config();
         config.useSingleServer()
                 .setAddress("redis://" + redisProperties.getHost() + ":" + redisProperties.getPort())
-                .setPassword(redisProperties.getPassword())
                 .setDatabase(redisProperties.getDatabase());
+        System.err.println(redisProperties.getPassword());
+        System.out.println(!"''".equals(redisProperties.getPassword()));
+        if (StrUtil.isNotEmpty(redisProperties.getPassword()) && !"''".equals(redisProperties.getPassword())) {
+            config.useSingleServer().setPassword(redisProperties.getPassword());
+        }
         return Redisson.create(config);
     }
+
 }

--- a/mallchat-chat-server/src/main/resources/application-test.properties
+++ b/mallchat-chat-server/src/main/resources/application-test.properties
@@ -7,7 +7,7 @@ mallchat.mysql.password=123456
 ##################redis??##################
 mallchat.redis.host=127.0.0.1
 mallchat.redis.port=6379
-mallchat.redis.password=123456
+mallchat.redis.password=''
 ##################jwt##################
 mallchat.jwt.secret=dsfsdfsdfsdfsd
 ##################???????##################


### PR DESCRIPTION
修复本地环境下Redis密码为空时启动报错，兼容对:‘’密码判断